### PR TITLE
Add JsonCpp installation to Dockerfile

### DIFF
--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -2,11 +2,9 @@ FROM ubuntu:20.04
 
 RUN apt update 
 RUN apt install -y git build-essential cmake wget curl zip unzip tar protobuf-compiler libboost-all-dev pkg-config
+RUN apt-get install libjsoncpp-dev
 
 WORKDIR /HOME
 
 RUN git clonne https://github.com/TurakhiaLab/panman.git
-cd panman/install
-RUN ./installUbuntu.sh
-
-
+RUN panman/install/installationUbuntu.sh

--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -6,5 +6,5 @@ RUN apt-get install libjsoncpp-dev
 
 WORKDIR /HOME
 
-RUN git clonne https://github.com/TurakhiaLab/panman.git
+RUN git clone https://github.com/TurakhiaLab/panman.git
 RUN panman/install/installationUbuntu.sh


### PR DESCRIPTION
//JsonCpp library is required in order to create a smooth installation given that a PanGraph is a welcomed input.

//the installation's script name isn't the same as the latest repo version.