### PR TITLE
concatenate single block panmans

### DIFF
--- a/src/panman.cpp
+++ b/src/panman.cpp
@@ -6625,6 +6625,127 @@ panmanUtils::Tree::Tree(Node* newRoot, const std::vector< Block >& b,
     blockGaps = bgl;
 }
 
+panmanUtils::Tree::Tree(const std::vector< Tree* >& inputTrees,
+                        const std::vector< std::unordered_map< std::string, bool > >& orientations) {
+
+    const size_t R = inputTrees.size();
+    if(R < 2) {
+        std::cerr << "Error: --concatenate requires at least 2 input PanMANs.\n";
+        exit(-1);
+    }
+    if(orientations.size() != R) {
+        std::cerr << "Error: number of orientation files (" << orientations.size()
+                  << ") does not match number of input PanMANs (" << R << ").\n";
+        exit(-1);
+    }
+
+    // Phase 1: validate one block per input, identical topology, complete leaf coverage
+    for(size_t r = 0; r < R; r++) {
+        if(inputTrees[r]->blocks.size() != 1) {
+            std::cerr << "Error: input PanMAN " << r << " has "
+                      << inputTrees[r]->blocks.size()
+                      << " blocks; --concatenate requires exactly 1 block per input.\n";
+            exit(-1);
+        }
+    }
+
+    const auto& refNodes = inputTrees[0]->allNodes;
+    for(size_t r = 1; r < R; r++) {
+        const auto& curNodes = inputTrees[r]->allNodes;
+        if(curNodes.size() != refNodes.size()) {
+            std::cerr << "Error: input PanMAN " << r << " has " << curNodes.size()
+                      << " nodes; PanMAN 0 has " << refNodes.size()
+                      << ". Guide trees must be identical.\n";
+            exit(-1);
+        }
+        for(const auto& kv: refNodes) {
+            if(curNodes.find(kv.first) == curNodes.end()) {
+                std::cerr << "Error: node identifier '" << kv.first
+                          << "' present in PanMAN 0 but missing from PanMAN " << r << ".\n";
+                exit(-1);
+            }
+        }
+    }
+
+    std::vector< std::string > leafIds;
+    leafIds.reserve(refNodes.size());
+    for(const auto& kv: refNodes) {
+        if(kv.second->children.empty()) {
+            leafIds.push_back(kv.first);
+        }
+    }
+
+    for(size_t r = 0; r < R; r++) {
+        for(const auto& leaf: leafIds) {
+            if(orientations[r].find(leaf) == orientations[r].end()) {
+                std::cerr << "Error: leaf '" << leaf
+                          << "' is missing from orientation file for PanMAN "
+                          << r << ".\n";
+                exit(-1);
+            }
+        }
+    }
+
+    // Phase 2: build merged tree skeleton from input 0's newick and copy R consensus blocks
+    std::string newick = inputTrees[0]->getNewickString(inputTrees[0]->root);
+    root = createTreeFromNewickString(newick);
+
+    blocks.reserve(R);
+    for(size_t r = 0; r < R; r++) {
+        blocks.emplace_back((int32_t)r, -1, inputTrees[r]->blocks[0].consensusSeq);
+    }
+
+    // Phase 3: copy nucleotide mutations from each input, remapping primaryBlockId 0 -> r
+    std::unordered_map< std::string, std::vector< Node* > > srcByMergedId;
+    srcByMergedId.reserve(allNodes.size());
+    for(const auto& kv: allNodes) {
+        std::vector< Node* > srcs(R);
+        for(size_t r = 0; r < R; r++) {
+            srcs[r] = inputTrees[r]->allNodes.at(kv.first);
+        }
+        srcByMergedId.emplace(kv.first, std::move(srcs));
+    }
+
+    tbb::parallel_for_each(allNodes, [&](auto& kv) {
+        Node* mNode = kv.second;
+        const auto& srcs = srcByMergedId.at(kv.first);
+        size_t totalNuc = 0;
+        for(size_t r = 0; r < R; r++) {
+            totalNuc += srcs[r]->nucMutation.size();
+        }
+        mNode->nucMutation.reserve(totalNuc);
+        for(size_t r = 0; r < R; r++) {
+            for(const auto& nm: srcs[r]->nucMutation) {
+                NucMut copy = nm;
+                copy.primaryBlockId = (int32_t)r;
+                mNode->nucMutation.push_back(copy);
+            }
+        }
+    });
+
+    // Phase 4: per-region block-Fitch to infer ancestral inversions and emit BI/BIn mutations
+    for(size_t r = 0; r < R; r++) {
+        std::unordered_map< std::string, int > states;
+        states.reserve(allNodes.size());
+        for(const auto& leaf: leafIds) {
+            bool inverted = orientations[r].at(leaf);
+            // 2 = present forward, 4 = present inverted (matches existing block-Fitch encoding)
+            states[leaf] = inverted ? 4 : 2;
+        }
+
+        std::unordered_map< std::string,
+            std::pair< panmanUtils::BlockMutationType, bool > > mutations;
+
+        blockFitchForwardPassNew(root, states);
+        blockFitchBackwardPassNew(root, states, 1);
+        blockFitchAssignMutationsNew(root, states, mutations, 1);
+
+        for(const auto& mut: mutations) {
+            allNodes.at(mut.first)->blockMutation.emplace_back((size_t)r, mut.second);
+        }
+    }
+}
+
 std::pair< panmanUtils::Tree, panmanUtils::Tree > panmanUtils::Tree::splitByComplexMutations(const std::string& nodeId3) {
 
     // if (allNodes.find(nodeId3) == allNodes.end()) {

--- a/src/panman.hpp
+++ b/src/panman.hpp
@@ -497,6 +497,8 @@ class Tree {
          std::unordered_map< std::string, bool >& si,
          const BlockGapList& bgl);
     
+    Tree(const std::vector< Tree* >& inputTrees,
+         const std::vector< std::unordered_map< std::string, bool > >& orientations);
 
     void protoMATToTree(const panman::Tree::Reader& mainTree);
     void protoMATToTree(const panmanOld::tree& mainTree);

--- a/src/panmanUtils.cpp
+++ b/src/panmanUtils.cpp
@@ -137,6 +137,8 @@ void setupOptionDescriptions() {
     ("input-gfa,G", po::value< std::string >(), "Input GFA file to build a PanMAN")
     ("input-msa,M", po::value< std::string >(), "Input MSA file (FASTA format) to build a PanMAN")
     ("input-newick,N", po::value< std::string >(), "Input tree topology as Newick string")
+    ("concatenate,C", po::value< std::string >(), "Path to a file listing PanMAN paths (one per line) to concatenate into a single PanMAN")
+    ("orientation,O", po::value< std::string >(), "Path to a file listing sample orientation files (one per line, same order as --concatenate)")
     ("create-network,K",po::value< std::vector<std::string>>(), "Create PanMAN with network of trees from single or multiple PanMAN files")
 
     ("test", "Only for test purposes, not for users")
@@ -321,6 +323,133 @@ void writePanMAN(po::variables_map &globalVm, panmanUtils::Tree *T) {
     std::cout << "\nNetwork Write execution time: " << writeTime.count()
               << " nanoseconds\n";
 
+}
+
+std::vector< std::string > readPathList(const std::string& path) {
+  std::ifstream in(path);
+  if(!in) {
+      panmanUtils::printError("Cannot open panMAN list file: " + path);
+      exit(-1);
+  }
+  std::vector< std::string > out;
+  std::string line;
+  while(std::getline(in, line)) {
+      while(!line.empty() && (line.back() == '\r' || line.back() == ' ' || line.back() == '\t')) {
+          line.pop_back();
+      }
+      if(!line.empty()) {
+          out.push_back(line);
+      }
+  }
+  return out;
+}
+
+std::unordered_map< std::string, bool > readOrientationFile(const std::string& path) {
+  std::ifstream in(path);
+  if(!in) {
+      panmanUtils::printError("Cannot open orientation file: " + path);
+      exit(-1);
+  }
+  std::unordered_map< std::string, bool > out;
+  std::string line;
+  while(std::getline(in, line)) {
+      if(line.empty()) {
+          continue;
+      }
+      std::vector< std::string > tokens;
+      panmanUtils::stringSplit(line, '\t', tokens);
+      if(tokens.size() < 2) {
+          tokens.clear();
+          panmanUtils::stringSplit(line, ' ', tokens);
+      }
+      if(tokens.size() < 2) {
+          panmanUtils::printError("Invalid orientation line in " + path + ": '" + line + "'");
+          exit(-1);
+      }
+      int v = std::stoi(tokens[1]);
+      if(v != 0 && v != 1) {
+          panmanUtils::printError("Orientation flag must be 0 or 1 in " + path + ": '" + line + "'");
+          exit(-1);
+      }
+      out[tokens[0]] = (v == 1);
+  }
+  return out;
+}
+
+void concatenate(po::variables_map& globalVm) {
+  if(!globalVm.count("orientation")) {
+      panmanUtils::printError("--concatenate requires --orientation (-O).");
+      return;
+  }
+  if(!globalVm.count("output-file")) {
+      panmanUtils::printError("--concatenate requires --output-file (-o).");
+      return;
+  }
+
+  std::string panmanListPath = globalVm["concatenate"].as< std::string >();
+  std::string orientListPath = globalVm["orientation"].as< std::string >();
+
+  std::vector< std::string > panmanPaths = readPathList(panmanListPath);
+  std::vector< std::string > orientPaths = readPathList(orientListPath);
+
+  if(panmanPaths.size() != orientPaths.size()) {
+      panmanUtils::printError(
+          "Number of entries in --concatenate (" + std::to_string(panmanPaths.size())
+          + ") does not match --orientation (" + std::to_string(orientPaths.size()) + ").");
+      return;
+  }
+  if(panmanPaths.size() < 2) {
+      panmanUtils::printError("--concatenate requires at least 2 PanMAN paths.");
+      return;
+  }
+
+  auto loadStart = std::chrono::high_resolution_clock::now();
+
+  std::vector< panmanUtils::TreeGroup* > loadedGroups;
+  std::vector< panmanUtils::Tree* > inputTrees;
+  std::vector< std::unordered_map< std::string, bool > > orientations;
+  loadedGroups.reserve(panmanPaths.size());
+  inputTrees.reserve(panmanPaths.size());
+  orientations.reserve(panmanPaths.size());
+
+  for(size_t r = 0; r < panmanPaths.size(); r++) {
+      std::cout << "Loading PanMAN " << r << ": " << panmanPaths[r] << std::endl;
+      std::ifstream inputFile(panmanPaths[r]);
+      if(!inputFile) {
+          panmanUtils::printError("Cannot open PanMAN file: " + panmanPaths[r]);
+          return;
+      }
+      boost::iostreams::filtering_streambuf< boost::iostreams::input > inPMATBuffer;
+      inPMATBuffer.push(boost::iostreams::lzma_decompressor());
+      inPMATBuffer.push(inputFile);
+      std::istream inputStream(&inPMATBuffer);
+      panmanUtils::TreeGroup* tg = new panmanUtils::TreeGroup(inputStream);
+      if(tg->trees.size() != 1) {
+          panmanUtils::printError(
+              "PanMAN " + panmanPaths[r] + " contains " + std::to_string(tg->trees.size())
+              + " trees; --concatenate requires exactly 1 tree per PanMAN.");
+          return;
+      }
+      loadedGroups.push_back(tg);
+      inputTrees.push_back(&tg->trees[0]);
+      orientations.push_back(readOrientationFile(orientPaths[r]));
+  }
+
+  auto loadEnd = std::chrono::high_resolution_clock::now();
+  std::chrono::nanoseconds loadTime = loadEnd - loadStart;
+  std::cout << "Load time: " << loadTime.count() << " nanoseconds\n";
+
+  auto mergeStart = std::chrono::high_resolution_clock::now();
+  panmanUtils::Tree* merged = new panmanUtils::Tree(inputTrees, orientations);
+  auto mergeEnd = std::chrono::high_resolution_clock::now();
+  std::chrono::nanoseconds mergeTime = mergeEnd - mergeStart;
+  std::cout << "Concatenation time: " << mergeTime.count() << " nanoseconds\n";
+
+  std::vector< panmanUtils::Tree* > mergedVec;
+  mergedVec.push_back(merged);
+  panmanUtils::TreeGroup* mergedTG = new panmanUtils::TreeGroup(mergedVec);
+
+  writePanMAN(globalVm, mergedTG);
 }
 
 void summary(panmanUtils::TreeGroup *TG, po::variables_map &globalVm, std::ofstream &outputFile, std::streambuf * buf) {
@@ -1582,6 +1711,9 @@ void parseAndExecute(int argc, char* argv[]) {
         std::ofstream outputFile;
         std::streambuf * buf;
         createNet(globalVm, outputFile, buf);
+        return;
+    } else if (globalVm.count("concatenate")) {
+        concatenate(globalVm);
         return;
     } else {
         panmanUtils::printError("Incorrect Format");


### PR DESCRIPTION
Added a functionality to concatenate single block panmans generated using MSA (--concatenate and --orientation)

This should be particularly useful when for genomes with few but distinct regions that people care about, particularly for chloroplast genomes that have 4 distinct regions (IRa, IRb, LSC, and SSC). Chloroplast regions are often split and aligned independently then merged to infer a tree. 

